### PR TITLE
[BUGFIX] Renames writeBufferHighWaterMark to writeBufferLowWaterMark

### DIFF
--- a/example-config/gremlin-server.yaml
+++ b/example-config/gremlin-server.yaml
@@ -35,5 +35,5 @@ maxChunkSize: 8192
 maxContentLength: 65536
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
-writeBufferHighWaterMark: 32768
+writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536


### PR DESCRIPTION
This pr:

* Corrects a typo in the configuration file and make sure that writeBufferLowWaterMark and writeBufferHighWaterMark are defined

Fixes: #11