### PR TITLE
Enable continuous deployment via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ script:
 
 after_script:
   - docker images
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin; bash push-images.sh $VERSION
+  on:
+    branch: master

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -15,22 +15,13 @@ Optionally build a specific version
 ./build-image.sh 0.3
 ```
 
-## Publishing
+## Deployment
 
-The `push-images.sh` script will push the docker images for all the versioned folders in the
-repository.
+We use continuous deployment via Travis CI to push images to Docker Hub.
+Every commit on `master` automatically triggers a deployment.
 
-```bash
-./push-images.sh
-```
-
-Optionally push a specific version
-
-```bash
-./push-images.sh 0.3
-```
-
-Prior to publishing, you'll need to login to [Docker Hub][DH] using the `docker login` command.
+Travis CI simply executes the `push-images.sh` script which will push the docker images for all the versioned folders
+in the repository.
 
 ## Updating and adding versions
 


### PR DESCRIPTION
I think for Docker images, it makes sense to just push new images for each commit on `master`.

I added the environment variables for the user name and the password via the web interface. `docker login` is done in a secure way that doesn't leak the password [as described in the Travis docs](https://docs.travis-ci.com/user/docker/#pushing-a-docker-image-to-a-registry).

Fixes #9