### PR TITLE
Add gremlin-console containers to compose configuration and support in entrypoint

### DIFF
--- a/0.2/docker-entrypoint.sh
+++ b/0.2/docker-entrypoint.sh
@@ -25,6 +25,7 @@ GREMLIN_YAML="${JANUS_CONFIG_DIR}/gremlin-server.yaml"
 if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chown -R janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  usermod -d ${JANUS_HOME} janusgraph
   chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
 
   exec chroot --skip-chdir --userspec janusgraph:janusgraph / "${BASH_SOURCE}" "$@"

--- a/0.2/docker-entrypoint.sh
+++ b/0.2/docker-entrypoint.sh
@@ -72,7 +72,7 @@ if [ "$1" == 'janusgraph' ]; then
     if ! [ -z "${JANUS_STORAGE_TIMEOUT:-}" ]; then
       F="$(mktemp --suffix .groovy)"
       echo "graph = JanusGraphFactory.open('${JANUS_CONFIG_DIR}/janusgraph.properties')" > $F
-      timeout "${JANUS_STORAGE_TIMEOUT}s" bash -c \
+      timeout -k 10 "${JANUS_STORAGE_TIMEOUT}s" bash -c \
         "until bin/gremlin.sh -e $F > /dev/null 2>&1; do echo \"waiting for storage...\"; sleep 5; done"
       rm -f "$F"
     fi

--- a/0.3/docker-entrypoint.sh
+++ b/0.3/docker-entrypoint.sh
@@ -25,6 +25,7 @@ GREMLIN_YAML="${JANUS_CONFIG_DIR}/gremlin-server.yaml"
 if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chown -R janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  usermod -d ${JANUS_HOME} janusgraph
   chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
 
   exec chroot --skip-chdir --userspec janusgraph:janusgraph / "${BASH_SOURCE}" "$@"

--- a/0.3/docker-entrypoint.sh
+++ b/0.3/docker-entrypoint.sh
@@ -72,7 +72,7 @@ if [ "$1" == 'janusgraph' ]; then
     if ! [ -z "${JANUS_STORAGE_TIMEOUT:-}" ]; then
       F="$(mktemp --suffix .groovy)"
       echo "graph = JanusGraphFactory.open('${JANUS_CONFIG_DIR}/janusgraph.properties')" > $F
-      timeout "${JANUS_STORAGE_TIMEOUT}s" bash -c \
+      timeout -k 10 "${JANUS_STORAGE_TIMEOUT}s" bash -c \
         "until bin/gremlin.sh -e $F > /dev/null 2>&1; do echo \"waiting for storage...\"; sleep 5; done"
       rm -f "$F"
     fi

--- a/0.4/docker-entrypoint.sh
+++ b/0.4/docker-entrypoint.sh
@@ -25,6 +25,7 @@ GREMLIN_YAML="${JANUS_CONFIG_DIR}/gremlin-server.yaml"
 if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chown -R janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  usermod -d ${JANUS_HOME} janusgraph
   chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
 
   exec chroot --skip-chdir --userspec janusgraph:janusgraph / "${BASH_SOURCE}" "$@"

--- a/0.4/docker-entrypoint.sh
+++ b/0.4/docker-entrypoint.sh
@@ -72,7 +72,7 @@ if [ "$1" == 'janusgraph' ]; then
     if ! [ -z "${JANUS_STORAGE_TIMEOUT:-}" ]; then
       F="$(mktemp --suffix .groovy)"
       echo "graph = JanusGraphFactory.open('${JANUS_CONFIG_DIR}/janusgraph.properties')" > $F
-      timeout "${JANUS_STORAGE_TIMEOUT}s" bash -c \
+      timeout -k 10 "${JANUS_STORAGE_TIMEOUT}s" bash -c \
         "until bin/gremlin.sh -e $F > /dev/null 2>&1; do echo \"waiting for storage...\"; sleep 5; done"
       rm -f "$F"
     fi

--- a/README.md
+++ b/README.md
@@ -45,18 +45,30 @@ gremlin> :> g.V().values('name')
 
 ### Using Docker Compose
 
-Start a JanusGraph Server instance using [`docker-compose.yml`](docker-compose.yml):
+Two docker-compose configurations are available, each supports different storage backend configuration:
+
+`docker-compose.yml` - Runs Janusgraph using only the Berkeley DB storage backend.
+`docker-compose-cql-es.yml` - Runs Janusgraph server with Cassandra + CQL for storage and Elasticearch for indexing.
+
+Start a JanusGraph Server instance using one of the above compose files:
 
 ```bash
-docker-compose -f docker-compose.yml up
+# BerkeleyDB
+docker-compose up
+# OR
+# Cassandra + CQL and Elasticsearch
+docker-compose -f docker-compose-cql-es.yml up
 ```
 
-Start a JanusGraph container running Gremlin Console in the same network using
-[`docker-compose.yml`](docker-compose.yml):
+The compose configurations also include a JanusGraph container running Gremlin Console in the same network.
+You can attach to the console and start using it:
 
 ```bash
-docker-compose -f docker-compose.yml run --rm \
-    -e GREMLIN_REMOTE_HOSTS=janusgraph janusgraph ./bin/gremlin.sh
+# BerkeleyDB
+docker attach janusgraph-default-gremlin-console
+# OR
+# Cassandra + CQL and Elasticsearch
+docker attach jce-gremlin-console
 ```
 
 ### Generate Config
@@ -90,9 +102,9 @@ The environment variables supported by the JanusGraph image are summarized below
 
 The `JANUS_PROPS_TEMPLATE` environment variable is used to define the base JanusGraph
 properties file. Values in the template properties file are used unless an alternate value
-for a given property is provided in the environment. The common usage will be to specify 
-a template for the general environment (e.g., `cassandra-es`) and then provide additional 
-individual configuration to override/extend the template. The available templates depend 
+for a given property is provided in the environment. The common usage will be to specify
+a template for the general environment (e.g., `cassandra-es`) and then provide additional
+individual configuration to override/extend the template. The available templates depend
 on the JanusGraph version (see [`conf/gremlin-server/janusgraph*.properties`][JG_TEMPLATES]).
 
 | `JANUS_PROPS_TEMPLATE` | Supported Versions |

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -68,7 +68,7 @@ if [ "$1" == 'janusgraph' ]; then
     if ! [ -z "${JANUS_STORAGE_TIMEOUT:-}" ]; then
       F="$(mktemp --suffix .groovy)"
       echo "graph = JanusGraphFactory.open('${JANUS_CONFIG_DIR}/janusgraph.properties')" > $F
-      timeout "${JANUS_STORAGE_TIMEOUT}s" bash -c \
+      timeout -k 10 "${JANUS_STORAGE_TIMEOUT}s" bash -c \
         "until bin/gremlin.sh -e $F > /dev/null 2>&1; do echo \"waiting for storage...\"; sleep 5; done"
       rm -f "$F"
     fi

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -21,6 +21,7 @@ GREMLIN_YAML="${JANUS_CONFIG_DIR}/gremlin-server.yaml"
 if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chown -R janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
+  usermod -d ${JANUS_HOME} janusgraph
   chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
 
   exec chroot --skip-chdir --userspec janusgraph:janusgraph / "${BASH_SOURCE}" "$@"

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -18,7 +18,8 @@ JANUS_PROPS="${JANUS_CONFIG_DIR}/janusgraph.properties"
 GREMLIN_YAML="${JANUS_CONFIG_DIR}/gremlin-server.yaml"
 
 # running as root; step down to run as janusgraph user
-if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
+if [[ "$(id -u)" == "0" ]] && [[ "$1" == 'janusgraph' || "$1" == 'gremlin-console' || "$1" == 'gremlin-console-remote' ]]; then
+  echo "Running root setup steps for '$1'"
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chown -R janusgraph:janusgraph ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   usermod -d ${JANUS_HOME} janusgraph
@@ -28,7 +29,8 @@ if [ "$1" == 'janusgraph' ] && [ "$(id -u)" == "0" ]; then
 fi
 
 # running as non root user
-if [ "$1" == 'janusgraph' ]; then
+if [[ "$1" == 'janusgraph' || "$1" == 'gremlin-console' || "$1" == 'gremlin-console-remote' ]] ; then
+  echo "Running non-root setup steps for '$1'"
   # setup config directory
   mkdir -p ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   cp conf/gremlin-server/janusgraph-${JANUS_PROPS_TEMPLATE}-server.properties ${JANUS_CONFIG_DIR}/janusgraph.properties
@@ -36,6 +38,11 @@ if [ "$1" == 'janusgraph' ]; then
   chown -R "$(id -u):$(id -g)" ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chmod 700 ${JANUS_DATA_DIR} ${JANUS_CONFIG_DIR}
   chmod -R 600 ${JANUS_CONFIG_DIR}/*
+
+  # override hosts for remote connections with Gremlin Console
+  if ! [ -z "${GREMLIN_REMOTE_HOSTS:-}" ]; then
+    sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote.yaml
+  fi
 
   # apply configuration from environment
   while IFS='=' read -r envvar_key envvar_val; do
@@ -65,22 +72,31 @@ if [ "$1" == 'janusgraph' ]; then
     cat "$GREMLIN_YAML"
     exit 0
   else
-    # wait for storage
-    if ! [ -z "${JANUS_STORAGE_TIMEOUT:-}" ]; then
-      F="$(mktemp --suffix .groovy)"
-      echo "graph = JanusGraphFactory.open('${JANUS_CONFIG_DIR}/janusgraph.properties')" > $F
-      timeout -k 10 "${JANUS_STORAGE_TIMEOUT}s" bash -c \
-        "until bin/gremlin.sh -e $F > /dev/null 2>&1; do echo \"waiting for storage...\"; sleep 5; done"
-      rm -f "$F"
+    if [ "$1" == 'janusgraph' ] ; then
+      # wait for storage
+      if ! [ -z "${JANUS_STORAGE_TIMEOUT:-}" ]; then
+        F="$(mktemp --suffix .groovy)"
+        echo "graph = JanusGraphFactory.open('${JANUS_CONFIG_DIR}/janusgraph.properties')" > $F
+        timeout -k 10 "${JANUS_STORAGE_TIMEOUT}s" bash -c \
+          "until bin/gremlin.sh -e $F > /dev/null 2>&1; do echo \"waiting for storage...\"; sleep 5; done"
+        rm -f "$F"
+      fi
+      echo "Starting janusgraph gremlin server"
+      exec ${JANUS_HOME}/bin/gremlin-server.sh ${JANUS_CONFIG_DIR}/gremlin-server.yaml
     fi
 
-    exec ${JANUS_HOME}/bin/gremlin-server.sh ${JANUS_CONFIG_DIR}/gremlin-server.yaml
-  fi
-fi
+    if [ "$1" == 'gremlin-console-remote' ] ; then
+      echo "Starting gremlin remote console"
+      exec ${JANUS_HOME}/bin/gremlin.sh -i scripts/remote-connect.groovy
+    fi
 
-# override hosts for remote connections with Gremlin Console
-if ! [ -z "${GREMLIN_REMOTE_HOSTS:-}" ]; then
-  sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote.yaml
+    if [ "$1" == 'gremlin-console' ] ; then
+      echo "Starting gremlin console"
+      C=$(mktemp --suffix .groovy)
+      echo "graph = JanusGraphFactory.open('${JANUS_CONFIG_DIR}/janusgraph.properties')" > $C
+      exec ${JANUS_HOME}/bin/gremlin.sh -i $C
+    fi
+  fi
 fi
 
 exec "$@"

--- a/docker-compose-cql-es.yml
+++ b/docker-compose-cql-es.yml
@@ -55,6 +55,22 @@ services:
       - "9200:9200"
     networks:
       - jce-network
+  gremlin-console:
+    image: janusgraph/janusgraph:latest
+    container_name: jce-gremlin-console
+    environment:
+      GREMLIN_REMOTE_HOSTS: janusgraph
+      JANUS_PROPS_TEMPLATE: cassandra-es
+      janusgraph.storage.backend: cql
+      janusgraph.storage.hostname: jce-cassandra
+      janusgraph.index.search.hostname: jce-elastic
+    stdin_open: yes
+    tty: yes
+    command: gremlin-console
+    networks:
+      - jce-network
+    depends_on:
+      - janusgraph
 
 networks:
   jce-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,19 @@ services:
     # The mounted volume only makes sense if JanusGraph is being run with the BerekeleyDB storage.
     volumes:
       - "janusgraph-default-data:/var/lib/janusgraph"
+  gremlin-console:
+    image: janusgraph/janusgraph:latest
+    container_name: janusgraph-default-gremlin-console
+    environment:
+      GREMLIN_REMOTE_HOSTS: janusgraph
+      JANUS_PROPS_TEMPLATE: berkeleyje
+    stdin_open: yes
+    tty: yes
+    command: gremlin-console
+    #volumes:
+    #  - ./build/docker-entrypoint.sh:/usr/local/bin/docker-entrypoint.sh:ro
+    depends_on:
+      - janusgraph
 
 volumes:
   janusgraph-default-data:


### PR DESCRIPTION
I found the user experience rather difficult when getting a gremlin console going (both remotely and directly). Especially for the CQL/ES storage backend.

I figured it'd be nice to have the gremlin console built in to the janusgraph image entrypoint and to provide containers in the compose files.

I ran `update.sh` but didn't commit the change in `JANUS_VERSION`. Feel free to run it and add another commit as required.