### PR TITLE
Restore original Apache license language [skip ci]

### DIFF
--- a/APACHE-2.0.txt
+++ b/APACHE-2.0.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 JanusGraph Docker Authors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -205,7 +205,7 @@ For convenience, copies of APACHE-2.0 and CC-BY-4.0 are included verbatim below.
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 JanusGraph Docker Authors
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The "How to apply the Apache license to your work" section is not supposed to be
modified in-place as it is not a copyright statement; this should stay as-is.