### PR TITLE
Use `latest` instead of numbered versions in docs & sample configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@
 This repository contains build scripts and configuration files for the official
 [JanusGraph][JG] Docker images, which are published on the [Docker Hub][docker-hub-url].
 
+> **Note:** even though the examples below and in the Docker Compose config
+> files (`*.yml`) use the `latest` image, when running a service in production,
+> be sure to specify a specific numeric version to
+> [avoid](https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375)
+> [unexpected](https://github.com/hadolint/hadolint/wiki/DL3007)
+> [behavior changes](https://vsupalov.com/docker-latest-tag/)
+> due to `latest` pointing to a new release version.
+
 ## Usage
 
 ### Start a JanusGraph Server instance
@@ -81,7 +89,7 @@ g.addV('demigod').property('name', 'hercules').iterate()
 JanusGraph-Docker has a single utility method. This method writes the JanusGraph Configuration and show the config afterward.
 
 ```bash
-docker run --rm -it janusgraph/janusgraph:0.4.0 janusgraph show-config
+docker run --rm -it janusgraph/janusgraph:latest janusgraph show-config
 ```
 
 **Default config locations are `/etc/opt/janusgraph/janusgraph.properties` and `/etc/opt/janusgraph/gremlin-server.yaml`.**

--- a/docker-compose-mount.yml
+++ b/docker-compose-mount.yml
@@ -16,7 +16,7 @@ version: "3"
 
 services:
   janusgraph:
-    image: janusgraph/janusgraph:0.2.0
+    image: janusgraph/janusgraph:latest
     container_name: janusgraph-mount
     ports:
       - "8182:8182"


### PR DESCRIPTION
This will keep the config evergreen, and makes it consistent with all the other
`docker-compose-*.yml` configs which do the same thing.