### PR TITLE
Support initialization with Groovy scripts

### DIFF
--- a/0.2/Dockerfile
+++ b/0.2/Dockerfile
@@ -26,6 +26,7 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph \
     JANUS_CONFIG_DIR=/etc/opt/janusgraph \
     JANUS_DATA_DIR=/var/lib/janusgraph \
+    JANUS_SERVER_TIMEOUT=30 \
     JANUS_STORAGE_TIMEOUT=60 \
     JANUS_PROPS_TEMPLATE=berkeleyje-lucene \
     janusgraph.index.search.directory=/var/lib/janusgraph/index \
@@ -49,13 +50,16 @@ RUN groupadd -r janusgraph --gid=999 && \
     rm -rf ${JANUS_HOME}/elasticsearch && \
     rm -rf ${JANUS_HOME}/javadocs && \
     rm -rf ${JANUS_HOME}/log && \
-    rm -rf ${JANUS_HOME}/examples
+    rm -rf ${JANUS_HOME}/examples && \
+    mkdir /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY load-initdb.sh /usr/local/bin/
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/load-initdb.sh && \
     chown -R janusgraph:janusgraph ${JANUS_HOME}
 
 EXPOSE 8182

--- a/0.2/docker-entrypoint.sh
+++ b/0.2/docker-entrypoint.sh
@@ -77,6 +77,8 @@ if [ "$1" == 'janusgraph' ]; then
       rm -f "$F"
     fi
 
+    /usr/local/bin/load-initdb.sh &
+
     exec ${JANUS_HOME}/bin/gremlin-server.sh ${JANUS_CONFIG_DIR}/gremlin-server.yaml
   fi
 fi

--- a/0.2/load-initdb.sh
+++ b/0.2/load-initdb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# NOTE: THIS FILE IS GENERATED VIA "update.sh"
+# DO NOT EDIT IT DIRECTLY; CHANGES WILL BE OVERWRITTEN.
+#
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit early if directory is empty
+if ! [ "$(ls -A /docker-entrypoint-initdb.d)" ]; then
+    exit 0
+fi
+
+# wait for JanusGraph Server
+if ! [ -z "${JANUS_SERVER_TIMEOUT:-}" ]; then
+    timeout "${JANUS_SERVER_TIMEOUT}s" bash -c \
+    "until true &>/dev/null </dev/tcp/127.0.0.1/8182; do echo \"waiting for JanusGraph Server...\"; sleep 5; done"
+fi
+
+for f in /docker-entrypoint-initdb.d/*; do
+  case "$f" in
+    *.groovy) echo "$0: running $f"; ${JANUS_HOME}/bin/gremlin.sh -e "$f"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done

--- a/0.3/Dockerfile
+++ b/0.3/Dockerfile
@@ -26,6 +26,7 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph \
     JANUS_CONFIG_DIR=/etc/opt/janusgraph \
     JANUS_DATA_DIR=/var/lib/janusgraph \
+    JANUS_SERVER_TIMEOUT=30 \
     JANUS_STORAGE_TIMEOUT=60 \
     JANUS_PROPS_TEMPLATE=berkeleyje-lucene \
     janusgraph.index.search.directory=/var/lib/janusgraph/index \
@@ -49,13 +50,16 @@ RUN groupadd -r janusgraph --gid=999 && \
     rm -rf ${JANUS_HOME}/elasticsearch && \
     rm -rf ${JANUS_HOME}/javadocs && \
     rm -rf ${JANUS_HOME}/log && \
-    rm -rf ${JANUS_HOME}/examples
+    rm -rf ${JANUS_HOME}/examples && \
+    mkdir /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY load-initdb.sh /usr/local/bin/
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/load-initdb.sh && \
     chown -R janusgraph:janusgraph ${JANUS_HOME}
 
 EXPOSE 8182

--- a/0.3/docker-entrypoint.sh
+++ b/0.3/docker-entrypoint.sh
@@ -77,6 +77,8 @@ if [ "$1" == 'janusgraph' ]; then
       rm -f "$F"
     fi
 
+    /usr/local/bin/load-initdb.sh &
+
     exec ${JANUS_HOME}/bin/gremlin-server.sh ${JANUS_CONFIG_DIR}/gremlin-server.yaml
   fi
 fi

--- a/0.3/load-initdb.sh
+++ b/0.3/load-initdb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# NOTE: THIS FILE IS GENERATED VIA "update.sh"
+# DO NOT EDIT IT DIRECTLY; CHANGES WILL BE OVERWRITTEN.
+#
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit early if directory is empty
+if ! [ "$(ls -A /docker-entrypoint-initdb.d)" ]; then
+    exit 0
+fi
+
+# wait for JanusGraph Server
+if ! [ -z "${JANUS_SERVER_TIMEOUT:-}" ]; then
+    timeout "${JANUS_SERVER_TIMEOUT}s" bash -c \
+    "until true &>/dev/null </dev/tcp/127.0.0.1/8182; do echo \"waiting for JanusGraph Server...\"; sleep 5; done"
+fi
+
+for f in /docker-entrypoint-initdb.d/*; do
+  case "$f" in
+    *.groovy) echo "$0: running $f"; ${JANUS_HOME}/bin/gremlin.sh -e "$f"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done

--- a/0.4/Dockerfile
+++ b/0.4/Dockerfile
@@ -26,6 +26,7 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph \
     JANUS_CONFIG_DIR=/etc/opt/janusgraph \
     JANUS_DATA_DIR=/var/lib/janusgraph \
+    JANUS_SERVER_TIMEOUT=30 \
     JANUS_STORAGE_TIMEOUT=60 \
     JANUS_PROPS_TEMPLATE=berkeleyje-lucene \
     janusgraph.index.search.directory=/var/lib/janusgraph/index \
@@ -49,13 +50,16 @@ RUN groupadd -r janusgraph --gid=999 && \
     rm -rf ${JANUS_HOME}/elasticsearch && \
     rm -rf ${JANUS_HOME}/javadocs && \
     rm -rf ${JANUS_HOME}/log && \
-    rm -rf ${JANUS_HOME}/examples
+    rm -rf ${JANUS_HOME}/examples && \
+    mkdir /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY load-initdb.sh /usr/local/bin/
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/load-initdb.sh && \
     chown -R janusgraph:janusgraph ${JANUS_HOME}
 
 EXPOSE 8182

--- a/0.4/docker-entrypoint.sh
+++ b/0.4/docker-entrypoint.sh
@@ -77,6 +77,8 @@ if [ "$1" == 'janusgraph' ]; then
       rm -f "$F"
     fi
 
+    /usr/local/bin/load-initdb.sh &
+
     exec ${JANUS_HOME}/bin/gremlin-server.sh ${JANUS_CONFIG_DIR}/gremlin-server.yaml
   fi
 fi

--- a/0.4/load-initdb.sh
+++ b/0.4/load-initdb.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# NOTE: THIS FILE IS GENERATED VIA "update.sh"
+# DO NOT EDIT IT DIRECTLY; CHANGES WILL BE OVERWRITTEN.
+#
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit early if directory is empty
+if ! [ "$(ls -A /docker-entrypoint-initdb.d)" ]; then
+    exit 0
+fi
+
+# wait for JanusGraph Server
+if ! [ -z "${JANUS_SERVER_TIMEOUT:-}" ]; then
+    timeout "${JANUS_SERVER_TIMEOUT}s" bash -c \
+    "until true &>/dev/null </dev/tcp/127.0.0.1/8182; do echo \"waiting for JanusGraph Server...\"; sleep 5; done"
+fi
+
+for f in /docker-entrypoint-initdb.d/*; do
+  case "$f" in
+    *.groovy) echo "$0: running $f"; ${JANUS_HOME}/bin/gremlin.sh -e "$f"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done

--- a/README.md
+++ b/README.md
@@ -59,6 +59,23 @@ docker-compose -f docker-compose.yml run --rm \
     -e GREMLIN_REMOTE_HOSTS=janusgraph janusgraph ./bin/gremlin.sh
 ```
 
+### Initialization
+
+When the container is started it will execute files with the extension
+`.groovy` that are found in `/docker-entrypoint-initdb.d` with the
+Gremlin Console.
+These scripts are only executed after the JanusGraph Server instance was
+started.
+So, they can [connect to it][JG_CONNECT_JAVA] and execute Gremlin traversals.
+
+For example, to add a vertex to the graph, create a file
+`/docker-entrypoint-initdb.d/add-vertex.groovy` with the following content:
+
+```groovy
+g = traversal().withRemote('conf/remote-graph.properties')
+g.addV('demigod').property('name', 'hercules').iterate()
+```
+
 ### Generate Config
 
 JanusGraph-Docker has a single utility method. This method writes the JanusGraph Configuration and show the config afterward.
@@ -83,6 +100,7 @@ The environment variables supported by the JanusGraph image are summarized below
 | `JANUS_PROPS_TEMPLATE` | JanusGraph properties file template (see [below](#properties-template)). The default properties file template is `berkeleyje-lucene`. |
 | `janusgraph.*` | Any JanusGraph configuration option to override in the template properties file, specified with an outer `janusgraph` namespace (e.g., `janusgraph.storage.hostname`). See [JanusGraph Configuration][JG_CONFIG] for available options. |
 | `gremlinserver.*` | Any Gremlin Server configuration option to override in the default configuration (YAML) file, specified with an outer `gremlinserver` namespace (e.g., `gremlinserver.threadPoolWorker`). See [Gremlin Server Configuration][GS_CONFIG] for available options. |
+| `JANUS_SERVER_TIMEOUT` | Timeout (seconds) used when waiting for Gremlin Server before executing initialization scripts. Default value is 30 seconds. |
 | `JANUS_STORAGE_TIMEOUT` | Timeout (seconds) used when waiting for the storage backend before starting Gremlin Server. Default value is 60 seconds. |
 | `GREMLIN_REMOTE_HOSTS` | Optional hostname for external Gremlin Server instance. Enables a container running Gremlin Console to connect to a remote server using `conf/remote.yaml`. |
 
@@ -212,6 +230,7 @@ see [`LICENSE.txt`](LICENSE.txt).
 [JG_BDB]: https://docs.janusgraph.org/latest/bdb.html
 [JG_CONFIG]: https://docs.janusgraph.org/latest/config-ref.html
 [JG_LUCENE]: https://docs.janusgraph.org/latest/lucene.html
+[JG_CONNECT_JAVA]: https://docs.janusgraph.org/connecting/java/
 [JG_TEMPLATES]: https://github.com/search?q=org:JanusGraph+repo:janusgraph+filename:janusgraph.properties%20path:janusgraph-dist/src/assembly/static/conf/gremlin-server
 [GS_CONFIG]: http://tinkerpop.apache.org/docs/current/reference/#_configuring_2
 [DH]: https://hub.docker.com/

--- a/build/Dockerfile-openjdk8.template
+++ b/build/Dockerfile-openjdk8.template
@@ -22,6 +22,7 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph \
     JANUS_CONFIG_DIR=/etc/opt/janusgraph \
     JANUS_DATA_DIR=/var/lib/janusgraph \
+    JANUS_SERVER_TIMEOUT=30 \
     JANUS_STORAGE_TIMEOUT=60 \
     JANUS_PROPS_TEMPLATE=berkeleyje-lucene \
     janusgraph.index.search.directory=/var/lib/janusgraph/index \
@@ -45,13 +46,16 @@ RUN groupadd -r janusgraph --gid=999 && \
     rm -rf ${JANUS_HOME}/elasticsearch && \
     rm -rf ${JANUS_HOME}/javadocs && \
     rm -rf ${JANUS_HOME}/log && \
-    rm -rf ${JANUS_HOME}/examples
+    rm -rf ${JANUS_HOME}/examples && \
+    mkdir /docker-entrypoint-initdb.d
 
 COPY docker-entrypoint.sh /usr/local/bin/
+COPY load-initdb.sh /usr/local/bin/
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
 RUN chmod 755 /usr/local/bin/docker-entrypoint.sh && \
+    chmod 755 /usr/local/bin/load-initdb.sh && \
     chown -R janusgraph:janusgraph ${JANUS_HOME}
 
 EXPOSE 8182

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -73,6 +73,8 @@ if [ "$1" == 'janusgraph' ]; then
       rm -f "$F"
     fi
 
+    /usr/local/bin/load-initdb.sh &
+
     exec ${JANUS_HOME}/bin/gremlin-server.sh ${JANUS_CONFIG_DIR}/gremlin-server.yaml
   fi
 fi

--- a/build/load-initdb.sh
+++ b/build/load-initdb.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2019 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# exit early if directory is empty
+if ! [ "$(ls -A /docker-entrypoint-initdb.d)" ]; then
+    exit 0
+fi
+
+# wait for JanusGraph Server
+if ! [ -z "${JANUS_SERVER_TIMEOUT:-}" ]; then
+    timeout "${JANUS_SERVER_TIMEOUT}s" bash -c \
+    "until true &>/dev/null </dev/tcp/127.0.0.1/8182; do echo \"waiting for JanusGraph Server...\"; sleep 5; done"
+fi
+
+for f in /docker-entrypoint-initdb.d/*; do
+  case "$f" in
+    *.groovy) echo "$0: running $f"; ${JANUS_HOME}/bin/gremlin.sh -e "$f"; echo ;;
+    *)        echo "$0: ignoring $f" ;;
+  esac
+  echo
+done

--- a/update.sh
+++ b/update.sh
@@ -72,6 +72,11 @@ for version in "${versions[@]}"; do
   template-generated-warning "#" >> $dir/docker-entrypoint.sh
   awk 'NR>1' build/docker-entrypoint.sh >> $dir/docker-entrypoint.sh
 
+  # copy load-initdb
+  head -n 1 build/load-initdb.sh > $dir/load-initdb.sh
+  template-generated-warning "#" >> $dir/load-initdb.sh
+  awk 'NR>1' build/load-initdb.sh >> $dir/load-initdb.sh
+
   # copy resources
   copy-with-template-generated-warning conf/janusgraph-berkeleyje-lucene-server.properties "#"
   copy-with-template-generated-warning conf/log4j-server.properties "#"


### PR DESCRIPTION
This only adds support for using Groovy scripts for initialization. The idea to also support GraphSON / Gryo files mentioned in #16 can still be added in a future PR if it's really needed, but I think that Groovy scripts are the easiest option to initialize the graph.

Fixes #16