### PR TITLE
Bug Fix: Unable to set gremlin server options that are not simple types (e.g. 'graphs') #44

### DIFF
--- a/0.4/Dockerfile
+++ b/0.4/Dockerfile
@@ -53,6 +53,10 @@ RUN groupadd -r janusgraph --gid=999 && \
     rm -rf ${JANUS_HOME}/examples && \
     mkdir /docker-entrypoint-initdb.d
 
+RUN curl -fSL https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64 -o /usr/local/bin/yq_linux_amd64 && \
+    chmod 755 /usr/local/bin/yq_linux_amd64 && \
+    ln -s /usr/local/bin/yq_linux_amd64 /usr/local/bin/yq
+    
 COPY docker-entrypoint.sh /usr/local/bin/
 COPY load-initdb.sh /usr/local/bin/
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/

--- a/0.4/docker-entrypoint.sh
+++ b/0.4/docker-entrypoint.sh
@@ -52,12 +52,8 @@ if [ "$1" == 'janusgraph' ]; then
       continue
     fi
 
-    # if the line exists replace it; otherwise append it
-    if grep -q -E "^\s*${envvar_key}\s*${delimiter}\.*" ${config_file}; then
-      sed -ri "s#^(\s*${envvar_key}\s*${delimiter}).*#\\1${envvar_val}#" ${config_file}
-    else
-      echo "${envvar_key}${delimiter}${envvar_val}" >> ${config_file}
-    fi
+    # add new or update existing field in configuration file
+    yq w -i ${config_file} ${envvar_key} ${envvar_val}
   done < <(env)
 
   if [ "$2" == 'show-config' ]; then

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The environment variables supported by the JanusGraph image are summarized below
 | ---- | ---- |
 | `JANUS_PROPS_TEMPLATE` | JanusGraph properties file template (see [below](#properties-template)). The default properties file template is `berkeleyje-lucene`. |
 | `janusgraph.*` | Any JanusGraph configuration option to override in the template properties file, specified with an outer `janusgraph` namespace (e.g., `janusgraph.storage.hostname`). See [JanusGraph Configuration][JG_CONFIG] for available options. |
-| `gremlinserver.*` | Any Gremlin Server configuration option to override in the default configuration (YAML) file, specified with an outer `gremlinserver` namespace (e.g., `gremlinserver.threadPoolWorker`). See [Gremlin Server Configuration][GS_CONFIG] for available options. |
+| `gremlinserver.*` | Any Gremlin Server configuration option to override in the default configuration (YAML) file, specified with an outer `gremlinserver` namespace (e.g., `gremlinserver.threadPoolWorker`). You can set or update nested options using additional dots (e.g., `gremlinserver.graphs.graph`) or an alternative syntax (e.g., `gremlin['graphs']['graph']`). See [Gremlin Server Configuration][GS_CONFIG] for available options. |
 | `JANUS_SERVER_TIMEOUT` | Timeout (seconds) used when waiting for Gremlin Server before executing initialization scripts. Default value is 30 seconds. |
 | `JANUS_STORAGE_TIMEOUT` | Timeout (seconds) used when waiting for the storage backend before starting Gremlin Server. Default value is 60 seconds. |
 | `GREMLIN_REMOTE_HOSTS` | Optional hostname for external Gremlin Server instance. Enables a container running Gremlin Console to connect to a remote server using `conf/remote.yaml`. |


### PR DESCRIPTION
Bug Fix: Unable to set gremlin server options that are not simple types (e.g. 'graphs') #44

Added new dependency yq which provides the underlying capability to edit individual fields and list items of any depth in a yaml file and output an updated file.

Signed-off-by: Michael Kaiser-Cross <mkaisercross@gmail.com>