### PR TITLE
Unable to set gremlin server options that are not simple types (e.g. 'graphs') #44

### DIFF
--- a/0.5/Dockerfile
+++ b/0.5/Dockerfile
@@ -53,14 +53,17 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_PROPS_TEMPLATE=berkeleyje-lucene \
     janusgraph.index.search.directory=/var/lib/janusgraph/index \
     janusgraph.storage.directory=/var/lib/janusgraph/data \
-    gremlinserver.graph=/etc/opt/janusgraph/janusgraph.properties \
+    gremlinserver.graphs.graph=/etc/opt/janusgraph/janusgraph.properties \
     gremlinserver.threadPoolWorker=1 \
     gremlinserver.gremlinPool=8
 
 RUN groupadd -r janusgraph --gid=999 && \
     useradd -r -g janusgraph --uid=999 janusgraph && \
+    printf "\\ndeb http://ppa.launchpad.net/rmescandon/yq/ubuntu xenial main\\n\
+deb-src http://ppa.launchpad.net/rmescandon/yq/ubuntu xenial main" >> /etc/apt/sources.list.d/janusgraph-dep.list
+RUN    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9A2D61F6BB03CED7522B8E7D6657DBE0CC86BB64 && \
     apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y krb5-user && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends krb5-user yq && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /docker-entrypoint-initdb.d
 

--- a/build/Dockerfile-openjdk8.template
+++ b/build/Dockerfile-openjdk8.template
@@ -49,14 +49,17 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_PROPS_TEMPLATE=berkeleyje-lucene \
     janusgraph.index.search.directory=/var/lib/janusgraph/index \
     janusgraph.storage.directory=/var/lib/janusgraph/data \
-    gremlinserver.graph=/etc/opt/janusgraph/janusgraph.properties \
+    gremlinserver.graphs.graph=/etc/opt/janusgraph/janusgraph.properties \
     gremlinserver.threadPoolWorker=1 \
     gremlinserver.gremlinPool=8
 
 RUN groupadd -r janusgraph --gid=999 && \
     useradd -r -g janusgraph --uid=999 janusgraph && \
+    printf "\\ndeb http://ppa.launchpad.net/rmescandon/yq/ubuntu xenial main\\n\
+deb-src http://ppa.launchpad.net/rmescandon/yq/ubuntu xenial main" >> /etc/apt/sources.list.d/janusgraph-dep.list
+RUN    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 9A2D61F6BB03CED7522B8E7D6657DBE0CC86BB64 && \
     apt-get update -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y krb5-user && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends krb5-user yq && \
     rm -rf /var/lib/apt/lists/* && \
     mkdir /docker-entrypoint-initdb.d
 

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -40,19 +40,23 @@ if [ "$1" == 'janusgraph' ]; then
   while IFS='=' read -r envvar_key envvar_val; do
     if [[ "${envvar_key}" =~ janusgraph\. ]] && [[ ! -z ${envvar_val} ]]; then
       # strip namespace and use properties file delimiter for janusgraph properties
-      config_file=${JANUS_PROPS} delimiter="=" envvar_key=${envvar_key#"janusgraph."}
-    elif [[ "${envvar_key}" =~ gremlinserver\. ]] && [[ ! -z ${envvar_val} ]]; then
-      # strip namespace, use yaml delimiter and add space after delimiter for gremlinserver properties
-      config_file=${GREMLIN_YAML} delimiter=":" envvar_key=${envvar_key#"gremlinserver."} envvar_val=" $envvar_val"
+      envvar_key=${envvar_key#"janusgraph."}
+      # Add new or update existing field in configuration file
+      if grep -q -E "^\s*${envvar_key}\s*=\.*" ${JANUS_PROPS}; then
+        sed -ri "s#^(\s*${envvar_key}\s*=).*#\\1${envvar_val}#" ${JANUS_PROPS}
+      else
+        echo "${envvar_key}=${envvar_val}" >> ${JANUS_PROPS}
+      fi
+    elif [[ "${envvar_key}" =~ gremlinserver(%d)?[.]{1}(.+) ]]; then
+      # Check for edit mode %d after prefix
+      if [[ ${BASH_REMATCH[1]} == "%d" ]]; then edit_mode="d"; else edit_mode="w"; fi
+      # strip namespace from env variable and get value
+      envvar_key=${BASH_REMATCH[2]}
+      if [[ edit_mode == "d" ]]; then envvar_val=""; fi
+      # add new or update existing field in configuration file
+      yq ${edit_mode} -P -i ${GREMLIN_YAML} ${envvar_key} ${envvar_val}
     else
       continue
-    fi
-
-    # if the line exists replace it; otherwise append it
-    if grep -q -E "^\s*${envvar_key}\s*${delimiter}\.*" ${config_file}; then
-      sed -ri "s#^(\s*${envvar_key}\s*${delimiter}).*#\\1${envvar_val}#" ${config_file}
-    else
-      echo "${envvar_key}${delimiter}${envvar_val}" >> ${config_file}
     fi
   done < <(env)
 


### PR DESCRIPTION
Reopening pull request for issue #44. Changes are now in a single commit a feature branch 'Issue_44' in forked repository and rebased from upstream master. 

**Description of Changes**
Previously there was no way to update gremlin server config options that were nested using the environment variables (gremlinserver.*). This has now been implemented with the help of the yq command which provides an easy syntax for editing fields in a YAML document. This also now provides the ability to delete fields. The syntax is a superset of the current the syntax so it will be backwards compatible and I have updated the build files for all previous versions 0.2, 0.3, and 0.4. The README has been updated and includes links to yq documentation and 3 examples of the syntax which I think give a good representation of how the syntax works.