### PR TITLE
example-config/gremlin-server.yaml fix - writeBufferHighWaterMark key  is used twice 

### DIFF
--- a/example-config/gremlin-server.yaml
+++ b/example-config/gremlin-server.yaml
@@ -35,5 +35,5 @@ maxChunkSize: 8192
 maxContentLength: 65536
 maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
-writeBufferHighWaterMark: 32768
+writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536


### PR DESCRIPTION
`writeBufferHighWaterMark` key is used twice in the example config. This PR updates the first one of them to `writeBufferLowWaterMark` .

https://github.com/JanusGraph/janusgraph-docker/blob/7c00f35e6e88c12379dd7d7f953b08005b6d1ffc/example-config/gremlin-server.yaml#L38-L39