### PR TITLE
Add a tagging policy

### DIFF
--- a/.dependency_license
+++ b/.dependency_license
@@ -15,6 +15,7 @@
 \.gitignore, Apache-2.0
 README.md, Apache-2.0
 BUILDING.md, Apache-2.0
+CHANGELOG.md, Apache-2.0
 AUTHORS.txt, Apache-2.0
 DCO.txt, Apache-2.0
 .csproj, Apache-2.0

--- a/0.2/Dockerfile
+++ b/0.2/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk as builder
+FROM openjdk:8-jdk-buster as builder
 
 ARG JANUS_VERSION=0.2.3
 
@@ -38,7 +38,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk
+FROM openjdk:8-jdk-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/0.3/Dockerfile
+++ b/0.3/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk as builder
+FROM openjdk:8-jdk-buster as builder
 
 ARG JANUS_VERSION=0.3.3
 
@@ -38,7 +38,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk
+FROM openjdk:8-jdk-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/0.4/Dockerfile
+++ b/0.4/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk as builder
+FROM openjdk:8-jdk-buster as builder
 
 ARG JANUS_VERSION=0.4.1
 
@@ -38,7 +38,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk
+FROM openjdk:8-jdk-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/0.5/Dockerfile
+++ b/0.5/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk as builder
+FROM openjdk:8-jdk-buster as builder
 
 ARG JANUS_VERSION=0.5.3
 ARG YQ_VERSION=3.4.1
@@ -42,7 +42,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk
+FROM openjdk:8-jdk-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog 
+
+* Allow changes to gremlin-server.yaml using yq3. #55
+* Change tagging logic. #73

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains build scripts and configuration files for the official
 > [avoid](https://medium.com/@mccode/the-misunderstood-docker-tag-latest-af3babfd6375)
 > [unexpected](https://github.com/hadolint/hadolint/wiki/DL3007)
 > [behavior changes](https://vsupalov.com/docker-latest-tag/)
-> due to `latest` pointing to a new release version.
+> due to `latest` pointing to a new release version, see our [Docker tagging Policy](#docker-tagging-policy).
 
 ## Usage
 
@@ -22,7 +22,7 @@ The default configuration uses the [Oracle Berkeley DB Java Edition][JG_BDB] sto
 and the [Apache Lucene][JG_LUCENE] indexing backend:
 
 ```bash
-docker run --rm --name janusgraph-default janusgraph/janusgraph:latest
+docker run --rm --name janusgraph-default docker.io/janusgraph/janusgraph:latest
 ```
 
 ### Connecting with Gremlin Console
@@ -32,7 +32,7 @@ using Gremlin Console:
 
 ```bash
 $ docker run --rm --link janusgraph-default:janusgraph -e GREMLIN_REMOTE_HOSTS=janusgraph \
-    -it janusgraph/janusgraph:latest ./bin/gremlin.sh
+    -it docker.io/janusgraph/janusgraph:latest ./bin/gremlin.sh
 
          \,,,/
          (o o)
@@ -89,7 +89,7 @@ g.addV('demigod').property('name', 'hercules').iterate()
 JanusGraph-Docker has a single utility method. This method writes the JanusGraph Configuration and show the config afterward.
 
 ```bash
-docker run --rm -it janusgraph/janusgraph:latest janusgraph show-config
+docker run --rm -it docker.io/janusgraph/janusgraph:latest janusgraph show-config
 ```
 
 **Default config locations are `/etc/opt/janusgraph/janusgraph.properties` and `/etc/opt/janusgraph/gremlin-server.yaml`.**
@@ -138,7 +138,7 @@ storage and server settings:
 docker run --name janusgraph-default \
     -e janusgraph.storage.berkeleyje.cache-percentage=80 \
     -e gremlinserver.threadPoolWorker=2 \
-    janusgraph/janusgraph:latest
+    docker.io/janusgraph/janusgraph:latest
 ```
 
 Inspect the configuration:
@@ -203,7 +203,7 @@ with the value `conf/JanusGraph-configurationmanagement.properties`:
 
 ```text
 $ docker run --rm -it -e gremlinserver.graphs.ConfigurationManagementGraph=\
-conf/JanusGraph-configurationmanagement.properties janusgraph/janusgraph:latest janusgraph show-config
+conf/JanusGraph-configurationmanagement.properties docker.io/janusgraph/janusgraph:latest janusgraph show-config
 ...
 graphs:
   graph: conf/gremlin-server/janusgraph-cql-es-server.properties
@@ -219,7 +219,7 @@ select the component following the prefix. Don't forget the trailing '='. For ex
 graphs.graph configuration property we can do the following:
 
 ```text
-$ docker run --rm -it -e gremlinserver%d.graphs.graph= janusgraph/janusgraph:latest janusgraph show-config
+$ docker run --rm -it -e gremlinserver%d.graphs.graph= docker.io/janusgraph/janusgraph:latest janusgraph show-config
 ...
 channelizer: org.apache.tinkerpop.gremlin.server.channel.WebSocketChannelizer
 graphs: {}
@@ -237,7 +237,7 @@ path contains special characters as we see in the example below.
 ```text
 $ docker run --rm -it -e gremlinserver.scriptEngines.gremlin-groovy\
 .plugins["org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin"]\
-.files[+]=/scripts/another-script.groovy janusgraph/janusgraph:latest janusgraph show-config
+.files[+]=/scripts/another-script.groovy docker.io/janusgraph/janusgraph:latest janusgraph show-config
 ...
 scriptEngines:
   gremlin-groovy:
@@ -278,6 +278,19 @@ $ docker-compose -f docker-compose-mount.yml up
 janusgraph-mount | chown: changing ownership of '/etc/opt/janusgraph/janusgraph.properties': Read-only file system
 ...
 ```
+
+## Docker Tagging Policy
+
+Here's the policy we follow for tagging our Docker images:
+
+| Tag            | Support level | Docker base image |
+|:--------------|:-------------|---|
+| latest         | <ul><li>latest JanusGraph release</li><li>no breaking changes guarantees</li></ul> | openjdk:8-jdk-buster |
+| 0.x            | <ul><li>newest patch-level version of JanusGraph</li><li>expect breaking changes</li></ul> | openjdk:8-jdk-buster |
+| 0.x.x          | <ul><li>defined JanusGraph version</li><li>breaking changes are only in this repo</li></ul> | openjdk:8-jdk-buster |
+| 0.x.x-revision | <ul><li>defined JanusGraph version</li><li>defined commit in JanusGraph-docker repo</li></ul> | openjdk:8-jdk-buster |
+
+We collect a list of changes in our docker images build process in our [CHANGELOG.md](./CHANGELOG.md)
 
 ## Community
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -21,22 +21,34 @@ version="${1:-}"
 # get all versions
 versions=($(ls -d [0-9]*))
 # get the last element of sorted version folders
-latest_version=${versions[${#versions[@]}-1]}
+latest_version="${versions[${#versions[@]}-1]}"
 
-REVISION=$(git rev-parse --short HEAD)
-CREATED=$(date -u +”%Y-%m-%dT%H:%M:%SZ”)
+REVISION="$(git rev-parse --short HEAD)"
+CREATED="$(date -u +”%Y-%m-%dT%H:%M:%SZ”)"
+IMAGE_NAME="docker.io/janusgraph/janusgraph"
+
+echo "REVISION: ${REVISION}"
+echo "CREATED: ${CREATED}"
+echo "IMAGE_NAME: ${IMAGE_NAME}"
 
 for v in "${versions[@]}"; do
   if [ -z "${version}" ] || [ "${version}" == "${v}" ]; then
-    # read full version from Dockerfile
-    full_version=$(grep "ARG JANUS_VERSION" ${v}/Dockerfile | head -n 1 | cut -d"=" -f 2)
+    # prepare docker tags
+    full_version="$(grep "ARG JANUS_VERSION" ${v}/Dockerfile | head -n 1 | cut -d"=" -f 2)"
+    full_version_with_revision="${full_version}-${REVISION}"
+
     # build and test image
-    docker build -f "${v}/Dockerfile" -t "janusgraph/janusgraph:${full_version}" ${v} --build-arg REVISION=$REVISION --build-arg CREATED=$CREATED
-    ./test-image.sh "janusgraph/janusgraph:${full_version}"
+    docker build -f "${v}/Dockerfile" -t "${IMAGE_NAME}:${full_version}" ${v} --build-arg REVISION="$REVISION" --build-arg CREATED="$CREATED"
+    ./test-image.sh "${IMAGE_NAME}:${full_version}"
+
     # add relevant tags
-    docker tag "janusgraph/janusgraph:${full_version}" "janusgraph/janusgraph:${v}"
+    docker tag "${IMAGE_NAME}:${full_version}" "${IMAGE_NAME}:${v}"
+    echo "Successfully tagged ${IMAGE_NAME}:${v}"
+    docker tag "${IMAGE_NAME}:${full_version}" "${IMAGE_NAME}:${full_version_with_revision}"
+    echo "Successfully tagged ${IMAGE_NAME}:${full_version_with_revision}"
     if [ "${v}" == "${latest_version}" ]; then
-      docker tag "janusgraph/janusgraph:${v}" "janusgraph/janusgraph:latest"
+      docker tag "${IMAGE_NAME}:${v}" "${IMAGE_NAME}:latest"
+      echo "Successfully tagged ${IMAGE_NAME}:latest"
     fi
   fi
 done

--- a/build/Dockerfile-openjdk8.template
+++ b/build/Dockerfile-openjdk8.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk as builder
+FROM openjdk:8-jdk-buster as builder
 
 ARG JANUS_VERSION=placeholder
 ARG YQ_VERSION=3.4.1
@@ -38,7 +38,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk
+FROM openjdk:8-jdk-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/docker-compose-cql-es.yml
+++ b/docker-compose-cql-es.yml
@@ -16,7 +16,7 @@ version: "3"
 
 services:
   janusgraph:
-    image: janusgraph/janusgraph:latest
+    image: docker.io/janusgraph/janusgraph:latest
     container_name: jce-janusgraph
     environment:
       JANUS_PROPS_TEMPLATE: cassandra-es

--- a/docker-compose-mount.yml
+++ b/docker-compose-mount.yml
@@ -16,7 +16,7 @@ version: "3"
 
 services:
   janusgraph:
-    image: janusgraph/janusgraph:latest
+    image: docker.io/janusgraph/janusgraph:latest
     container_name: janusgraph-mount
     ports:
       - "8182:8182"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ version: "3"
 
 services:
   janusgraph:
-    image: janusgraph/janusgraph:latest
+    image: docker.io/janusgraph/janusgraph:latest
     container_name: janusgraph-default
     ports:
       - "8182:8182"


### PR DESCRIPTION
Fixes #72

* Add a tagging policy to the readme.md
* Tag all images with extra tag which contains a short commit hash
* Use fullpath to push images docker.io/janusgraph/janusgraph instead of janusgraph/janusgraph
* Use fullpath in all examples
* Quote most variables in build-images.sh and push-images.sh
* Add changelog.md
 
Signed-off-by: Jan Jansen <jan.jansen@gdata.de>