### PR TITLE
Add container scanning

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,8 +16,6 @@ name: Build Images
 
 on:
   push:
-    branches-ignore:
-      - "master"
   pull_request:
 
 jobs:
@@ -30,3 +28,15 @@ jobs:
     - uses: actions/checkout@v2
     - name: build images
       run: ./build-images.sh ${{ matrix.version }}
+    - name: Run Trivy vulnerability scanner
+      uses: aquasecurity/trivy-action@master
+      with:
+        image-ref: 'docker.io/janusgraph/janusgraph:${{ matrix.version }}'
+        format: 'template'
+        template: '@/contrib/sarif.tpl'
+        output: 'trivy-results.sarif'
+
+    - name: Upload Trivy scan results to GitHub Security tab
+      uses: github/codeql-action/upload-sarif@v1
+      with:
+        sarif_file: 'trivy-results.sarif'

--- a/0.2/Dockerfile
+++ b/0.2/Dockerfile
@@ -16,14 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk-buster as builder
+FROM debian:buster-slim as builder
 
 ARG JANUS_VERSION=0.2.3
 
 ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph
 
-RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip -o janusgraph.zip && \
+RUN apt update -y && apt install -y gpg unzip curl && \
+    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip -o janusgraph.zip && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip.asc -o janusgraph.zip.asc && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/KEYS -o KEYS && \
     gpg --import KEYS && \
@@ -38,7 +39,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk-buster
+FROM openjdk:8-jre-slim-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/0.3/Dockerfile
+++ b/0.3/Dockerfile
@@ -16,14 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk-buster as builder
+FROM debian:buster-slim as builder
 
 ARG JANUS_VERSION=0.3.3
 
 ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph
 
-RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip -o janusgraph.zip && \
+RUN apt update -y && apt install -y gpg unzip curl && \
+    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip -o janusgraph.zip && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip.asc -o janusgraph.zip.asc && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/KEYS -o KEYS && \
     gpg --import KEYS && \
@@ -38,7 +39,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk-buster
+FROM openjdk:8-jre-slim-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/0.4/Dockerfile
+++ b/0.4/Dockerfile
@@ -16,14 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk-buster as builder
+FROM debian:buster-slim as builder
 
 ARG JANUS_VERSION=0.4.1
 
 ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph
 
-RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip -o janusgraph.zip && \
+RUN apt update -y && apt install -y gpg unzip curl && \
+    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip -o janusgraph.zip && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}-hadoop2.zip.asc -o janusgraph.zip.asc && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/KEYS -o KEYS && \
     gpg --import KEYS && \
@@ -38,7 +39,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk-buster
+FROM openjdk:8-jre-slim-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/0.5/Dockerfile
+++ b/0.5/Dockerfile
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk-buster as builder
+FROM debian:buster-slim as builder
 
 ARG JANUS_VERSION=0.5.3
 ARG YQ_VERSION=3.4.1
@@ -26,7 +26,8 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
 
 WORKDIR /opt
 
-RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip -o janusgraph.zip && \
+RUN apt update -y && apt install -y gpg unzip curl && \
+    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip -o janusgraph.zip && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip.asc -o janusgraph.zip.asc && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/KEYS -o KEYS && \
     curl -fSL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o yq && \
@@ -42,7 +43,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk-buster
+FROM openjdk:8-jre-slim-buster
 
 ARG CREATED=test
 ARG REVISION=test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 * Allow changes to gremlin-server.yaml using yq3. #55
 * Change tagging logic. #73
+* Switch base layer to 8-jre-slim-buster #75

--- a/README.md
+++ b/README.md
@@ -285,10 +285,10 @@ Here's the policy we follow for tagging our Docker images:
 
 | Tag            | Support level | Docker base image |
 |:--------------|:-------------|---|
-| latest         | <ul><li>latest JanusGraph release</li><li>no breaking changes guarantees</li></ul> | openjdk:8-jdk-buster |
-| 0.x            | <ul><li>newest patch-level version of JanusGraph</li><li>expect breaking changes</li></ul> | openjdk:8-jdk-buster |
-| 0.x.x          | <ul><li>defined JanusGraph version</li><li>breaking changes are only in this repo</li></ul> | openjdk:8-jdk-buster |
-| 0.x.x-revision | <ul><li>defined JanusGraph version</li><li>defined commit in JanusGraph-docker repo</li></ul> | openjdk:8-jdk-buster |
+| latest         | <ul><li>latest JanusGraph release</li><li>no breaking changes guarantees</li></ul> | openjdk:8-jre-slim-buster |
+| 0.x            | <ul><li>newest patch-level version of JanusGraph</li><li>expect breaking changes</li></ul> | openjdk:8-jre-slim-buster |
+| 0.x.x          | <ul><li>defined JanusGraph version</li><li>breaking changes are only in this repo</li></ul> | openjdk:8-jre-slim-buster |
+| 0.x.x-revision | <ul><li>defined JanusGraph version</li><li>defined commit in JanusGraph-docker repo</li></ul> | openjdk:8-jre-slim-buster |
 
 We collect a list of changes in our docker images build process in our [CHANGELOG.md](./CHANGELOG.md)
 

--- a/build/Dockerfile-openjdk8.template
+++ b/build/Dockerfile-openjdk8.template
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM openjdk:8-jdk-buster as builder
+FROM debian:buster-slim as builder
 
 ARG JANUS_VERSION=placeholder
 ARG YQ_VERSION=3.4.1
@@ -22,7 +22,8 @@ ENV JANUS_VERSION=${JANUS_VERSION} \
 
 WORKDIR /opt
 
-RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip -o janusgraph.zip && \
+RUN apt update -y && apt install -y gpg unzip curl && \
+    curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip -o janusgraph.zip && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/janusgraph-${JANUS_VERSION}.zip.asc -o janusgraph.zip.asc && \
     curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANUS_VERSION}/KEYS -o KEYS && \
     curl -fSL https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o yq && \
@@ -38,7 +39,7 @@ RUN curl -fSL https://github.com/JanusGraph/janusgraph/releases/download/v${JANU
 COPY conf/janusgraph-berkeleyje-lucene-server.properties conf/log4j-server.properties ${JANUS_HOME}/conf/gremlin-server/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jdk-buster
+FROM openjdk:8-jre-slim-buster
 
 ARG CREATED=test
 ARG REVISION=test


### PR DESCRIPTION
Part of #60

* Add security scanning using AquaSecurity Trivy
* Security scan results can be found here: https://github.com/JanusGraph/janusgraph-docker/security/code-scanning
* Use openjdk:8-jre-slim-buster instead of openjdk:8-jdk

Signed-off-by: Jan Jansen <jan.jansen@gdata.de>