### PR TITLE
Delete component in gremlin-server.yml does not work #78

### DIFF
--- a/0.5/docker-entrypoint.sh
+++ b/0.5/docker-entrypoint.sh
@@ -62,7 +62,7 @@ if [ "$1" == 'janusgraph' ]; then
     else
       continue
     fi
-  done < <(env)
+  done < <(env | sort -r)
 
   if [ "$2" == 'show-config' ]; then
     echo "# contents of ${JANUS_PROPS}"

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -58,7 +58,7 @@ if [ "$1" == 'janusgraph' ]; then
     else
       continue
     fi
-  done < <(env)
+  done < <(env | sort -r)
 
   if [ "$2" == 'show-config' ]; then
     echo "# contents of ${JANUS_PROPS}"


### PR DESCRIPTION
Fixes #78

* Updated docker-entrypoint.sh to first sort environment variables by the key name in reverse order using GNU sort. This means any keys with 'gremlinserver' variables are processed first followed by 'gremlinserver%d' variables. This ensures a delete will take precedence over a set. This seems like a more reasonable behavior when there is a conflict where there is an environment variable trying to both set and delete the same yaml property e.g. ENV fields in Dockerfile as well as a user defined environment variable.

Signed-off-by: Michael Kaiser-Cross <mkaisercross@gmail.com>