### PR TITLE
Remote subgraph traversal

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-* text eol=lf

--- a/0.5/conf/gremlin-server.yaml
+++ b/0.5/conf/gremlin-server.yaml
@@ -31,19 +31,33 @@ scriptEngines:
       org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]}
       org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/empty-sample.groovy]}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
+    config:
+      ioRegistries:
+        - org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry
+        - org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
+    config: { serializeResultToString: true }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
   # Older serialization versions for backwards compatibility:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0
+    config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0
+    config: { serializeResultToString: true }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }
 processors:
-  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
-  - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+  - className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor
+    config: { sessionTimeout: 28800000 }
+  - className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor
+    config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }
 metrics:
   consoleReporter: {enabled: true, interval: 180000}
   csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv}
@@ -59,5 +73,3 @@ maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536
-threadPoolWorker: 1
-gremlinPool: 8

--- a/build/conf/gremlin-server.yaml
+++ b/build/conf/gremlin-server.yaml
@@ -27,19 +27,33 @@ scriptEngines:
       org.apache.tinkerpop.gremlin.jsr223.ImportGremlinPlugin: {classImports: [java.lang.Math], methodImports: [java.lang.Math#*]}
       org.apache.tinkerpop.gremlin.jsr223.ScriptFileGremlinPlugin: {files: [scripts/empty-sample.groovy]}
 serializers:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
+    config:
+      ioRegistries:
+        - org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry
+        - org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
+    config: { serializeResultToString: true }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
   # Older serialization versions for backwards compatibility:
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0, config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0, config: { serializeResultToString: true }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
-  - { className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0, config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }}
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoLiteMessageSerializerV1d0
+    config: {ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV1d0
+    config: { serializeResultToString: true }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV2d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerGremlinV1d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }
+  - className: org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV1d0
+    config: { ioRegistries: [org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistryV1d0] }
 processors:
-  - { className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor, config: { sessionTimeout: 28800000 }}
-  - { className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor, config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }}
+  - className: org.apache.tinkerpop.gremlin.server.op.session.SessionOpProcessor
+    config: { sessionTimeout: 28800000 }
+  - className: org.apache.tinkerpop.gremlin.server.op.traversal.TraversalOpProcessor
+    config: { cacheExpirationTime: 600000, cacheMaxSize: 1000 }
 metrics:
   consoleReporter: {enabled: true, interval: 180000}
   csvReporter: {enabled: true, interval: 180000, fileName: /tmp/gremlin-server-metrics.csv}
@@ -55,5 +69,3 @@ maxAccumulationBufferComponents: 1024
 resultIterationBatchSize: 64
 writeBufferLowWaterMark: 32768
 writeBufferHighWaterMark: 65536
-threadPoolWorker: 1
-gremlinPool: 8

--- a/build/conf/remote-subgraphs.yaml
+++ b/build/conf/remote-subgraphs.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+hosts:
+  - janusgraph
+
+port: 8182
+
+serializer:
+  className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
+  config:
+    ioRegistries:
+      - org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry
+      - org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0
+


### PR DESCRIPTION
The ability to return subgraphs is not possible because the TinkerIoRegistryV3d0 is not included in the gremlin-server.yaml.
```
serializers:
...
  - className: org.apache.tinkerpop.gremlin.driver.ser.GryoMessageSerializerV3d0
    config:
      ioRegistries:
        - org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry
        - org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0
...
```
As was pointed out by @mkaisercross a similar behavior can be achieved with environment parameters.
The question is whether subgraph serialization should be allowed by default or not. 
```
docker run -it -e gremlinserver.serializers[2].config.ioRegistries[+]=org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerIoRegistryV3d0 janusgraph/janusgraph:latest janusgraph show-config
```
