### PR TITLE
prevent LF from being replaced by CRLF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,15 @@
+# Copyright 2021 JanusGraph Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 * text eol=lf


### PR DESCRIPTION
Windows 10 tends to insert CRLF which causes problems for docker.
The .gitattributes has options for addressing this problem.
https://git-scm.com/book/en/v2/Customizing-Git-Git-Attributes