### PR TITLE
Properly parse and process janusgraph supported environment variables

### DIFF
--- a/0.6/docker-entrypoint.sh
+++ b/0.6/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [ "$1" == 'janusgraph' ]; then
   chmod -R 600 ${JANUS_CONFIG_DIR}/*
 
   # apply configuration from environment
-  while IFS='=' read -r envvar_key envvar_val; do
+  while IFS=' ' read -r envvar_key envvar_val; do
     if [[ "${envvar_key}" =~ janusgraph\. ]] && [[ ! -z ${envvar_val} ]]; then
       # strip namespace and use properties file delimiter for janusgraph properties
       envvar_key=${envvar_key#"janusgraph."}
@@ -62,7 +62,7 @@ if [ "$1" == 'janusgraph' ]; then
     else
       continue
     fi
-  done < <(env | sort -r)
+  done < <(env | sort -r | awk -F= '{ st = index($0, "="); print $1 " " substr($0, st+1) }')
 
   if [ "$2" == 'show-config' ]; then
     echo "# contents of ${JANUS_PROPS}"

--- a/0.6/docker-entrypoint.sh
+++ b/0.6/docker-entrypoint.sh
@@ -41,7 +41,7 @@ if [ "$1" == 'janusgraph' ]; then
   chmod -R 600 ${JANUS_CONFIG_DIR}/*
 
   # apply configuration from environment
-  while IFS=' ' read -r envvar_key envvar_val; do
+  while IFS='=' read -r envvar_key envvar_val; do
     if [[ "${envvar_key}" =~ janusgraph\. ]] && [[ ! -z ${envvar_val} ]]; then
       # strip namespace and use properties file delimiter for janusgraph properties
       envvar_key=${envvar_key#"janusgraph."}
@@ -62,7 +62,7 @@ if [ "$1" == 'janusgraph' ]; then
     else
       continue
     fi
-  done < <(env | sort -r | awk -F= '{ st = index($0, "="); print $1 " " substr($0, st+1) }')
+  done < <(env | sort -r)
 
   if [ "$2" == 'show-config' ]; then
     echo "# contents of ${JANUS_PROPS}"

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -37,7 +37,7 @@ if [ "$1" == 'janusgraph' ]; then
   chmod -R 600 ${JANUS_CONFIG_DIR}/*
 
   # apply configuration from environment
-  while IFS='=' read -r envvar_key envvar_val; do
+  while IFS=' ' read -r envvar_key envvar_val; do
     if [[ "${envvar_key}" =~ janusgraph\. ]] && [[ ! -z ${envvar_val} ]]; then
       # strip namespace and use properties file delimiter for janusgraph properties
       envvar_key=${envvar_key#"janusgraph."}
@@ -58,7 +58,7 @@ if [ "$1" == 'janusgraph' ]; then
     else
       continue
     fi
-  done < <(env | sort -r)
+  done < <(env | sort -r | awk -F= '{ st = index($0, "="); print $1 " " substr($0, st+1) }')
 
   if [ "$2" == 'show-config' ]; then
     echo "# contents of ${JANUS_PROPS}"


### PR DESCRIPTION
When passing janusgraph env variables whose value might be ending with an `=` character, the `docker-entrypoint.sh` script incorrectly strips the last character. I encountered this while providing an Amazon Keyspace service name e.g
`docker run -e "janusgraph.storage.password=L2Rldi9udWxsCg=" janusgraph/janusgraph`, this ends up as `storage.password = L2Rldi9udWxsCg` in the `janusgraph.properties'

The solution makes use if `awk` command to pass the entire `envvar_value` substring.