### PR TITLE
Also support remote-objects.yaml

### DIFF
--- a/0.6/docker-entrypoint.sh
+++ b/0.6/docker-entrypoint.sh
@@ -90,6 +90,7 @@ fi
 # override hosts for remote connections with Gremlin Console
 if ! [ -z "${GREMLIN_REMOTE_HOSTS:-}" ]; then
   sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote.yaml
+  sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote-objects.yaml
 fi
 
 exec "$@"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The environment variables supported by the JanusGraph image are summarized below
 | `gremlinserver.*` | Any Gremlin Server configuration option to override in the default configuration (YAML) file, specified with an outer `gremlinserver` namespace (e.g., `gremlinserver.threadPoolWorker`). You can set or update nested options using additional dots (e.g., `gremlinserver.graphs.graph`). See [Gremlin Server Configuration][GS_CONFIG] for available options. See [Gremlin Server Environment Variable Syntax](#Gremlin-Server-Environment-Variable-Syntax) section below for help editing gremlin server configuration using environment variables. | no default value` | 
 | `JANUS_SERVER_TIMEOUT` | Timeout (seconds) used when waiting for Gremlin Server before executing initialization scripts. | `30` |
 | `JANUS_STORAGE_TIMEOUT` | Timeout (seconds) used when waiting for the storage backend before starting Gremlin Server. | `60` |
-| `GREMLIN_REMOTE_HOSTS` | Optional hostname for external Gremlin Server instance. Enables a container running Gremlin Console to connect to a remote server using `conf/remote.yaml`. | no default value | 
+| `GREMLIN_REMOTE_HOSTS` | Optional hostname for external Gremlin Server instance. Enables a container running Gremlin Console to connect to a remote server using `conf/remote.yaml` (or `remote-objects.yaml`). | no default value | 
 | `JANUS_INITDB_DIR` | Defines the location of the initialization scripts.  | `/docker-entrypoint-initdb.d` |
 
 #### Properties template

--- a/build/docker-entrypoint.sh
+++ b/build/docker-entrypoint.sh
@@ -86,6 +86,7 @@ fi
 # override hosts for remote connections with Gremlin Console
 if ! [ -z "${GREMLIN_REMOTE_HOSTS:-}" ]; then
   sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote.yaml
+  sed -i "s/hosts\s*:.*/hosts: [$GREMLIN_REMOTE_HOSTS]/" ${JANUS_HOME}/conf/remote-objects.yaml
 fi
 
 exec "$@"


### PR DESCRIPTION
We only applied `GREMLIN_REMOTE_HOSTS` to the `remote.yaml`, but we should also use it for the `remote-objects.yaml` which can for example be used to create remote traversals instead of sending traversals as strings to the server.

This change was initially made by @phreed in PR #88
who unfortunately didn't come back to it to update the PR to only update the latest version (currently 0.6).