### PR TITLE
Correct `org.opencontainers.image.created` label

### DIFF
--- a/build-images.sh
+++ b/build-images.sh
@@ -24,7 +24,7 @@ versions=($(ls -d [0-9]*))
 latest_version="${versions[${#versions[@]}-1]}"
 
 REVISION="$(git rev-parse --short HEAD)"
-CREATED="$(date -u +”%Y-%m-%dT%H:%M:%SZ”)"
+CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 IMAGE_NAME="docker.io/janusgraph/janusgraph"
 
 echo "REVISION: ${REVISION}"


### PR DESCRIPTION
The current [OCI Image Format Specification's Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys) defines the `org.opencontainers.image.created` label as follow:

> `org.opencontainers.image.created` date and time on which the image was built, conforming to [RFC 3339](https://tools.ietf.org/html/rfc3339#section-5.6).

However, the JanusGraph-defined `org.opencontainers.image.created` label seems to unintentionally include two right double quotes resulting a potentially undesired format:

```
# docker image inspect janusgraph/janusgraph
[
    {
[...]
        "ContainerConfig": {
[...]
            "Labels": {
                "org.opencontainers.image.created": "”2022-12-16T14:01:56Z”",
                "org.opencontainers.image.description": "Official JanusGraph Docker image",
                "org.opencontainers.image.documentation": "https://docs.janusgraph.org/v0.6/",
                "org.opencontainers.image.license": "Apache-2.0",
                "org.opencontainers.image.revision": "62cab84",
                "org.opencontainers.image.source": "https://github.com/JanusGraph/janusgraph-docker/",
                "org.opencontainers.image.title": "JanusGraph Docker Image",
                "org.opencontainers.image.url": "https://janusgraph.org/",
                "org.opencontainers.image.vendor": "JanusGraph",
                "org.opencontainers.image.version": "0.6.2"
            }
        },
[...]
        "Config": {
[...]
            "Labels": {
                "org.opencontainers.image.created": "”2022-12-16T14:01:56Z”",
                "org.opencontainers.image.description": "Official JanusGraph Docker image",
                "org.opencontainers.image.documentation": "https://docs.janusgraph.org/v0.6/",
                "org.opencontainers.image.license": "Apache-2.0",
                "org.opencontainers.image.revision": "62cab84",
                "org.opencontainers.image.source": "https://github.com/JanusGraph/janusgraph-docker/",
                "org.opencontainers.image.title": "JanusGraph Docker Image",
                "org.opencontainers.image.url": "https://janusgraph.org/",
                "org.opencontainers.image.vendor": "JanusGraph",
                "org.opencontainers.image.version": "0.6.2"
            }
        },
[...]
    }
]
```

This PR removes the unneeded right double quotes. Do note this change was not tested and might need validation before merging.