### PR TITLE
Upgrade to JanusGraph 0.6.3

### DIFF
--- a/0.6/Dockerfile
+++ b/0.6/Dockerfile
@@ -19,7 +19,7 @@
 FROM debian:buster-slim as builder
 
 ARG TARGETARCH
-ARG JANUS_VERSION=0.6.2
+ARG JANUS_VERSION=0.6.3
 ARG YQ_VERSION=3.4.1
 
 ENV JANUS_VERSION=${JANUS_VERSION} \
@@ -46,11 +46,11 @@ RUN apt update -y && apt install -y gpg unzip curl && \
 COPY conf/ ${JANUS_HOME}/conf/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM eclipse-temurin:8-jdk
+FROM eclipse-temurin:8-jre
 
 ARG CREATED=test
 ARG REVISION=test
-ARG JANUS_VERSION=0.6.2
+ARG JANUS_VERSION=0.6.3
 
 ENV JANUS_VERSION=${JANUS_VERSION} \
     JANUS_HOME=/opt/janusgraph \

--- a/1.0/Dockerfile
+++ b/1.0/Dockerfile
@@ -46,7 +46,7 @@ RUN apt update -y && apt install -y gpg unzip curl && \
 COPY conf/ ${JANUS_HOME}/conf/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM eclipse-temurin:11-jdk
+FROM eclipse-temurin:11-jre
 
 ARG CREATED=test
 ARG REVISION=test

--- a/README.md
+++ b/README.md
@@ -300,10 +300,10 @@ Here's the policy we follow for tagging our Docker images:
 
 | Tag            | Support level | Docker base image      |
 |:--------------|:-------------|------------------------|
-| latest         | <ul><li>latest JanusGraph release</li><li>no breaking changes guarantees</li></ul> | eclipse-temurin:11-jdk |
-| x.x            | <ul><li>newest patch-level version of JanusGraph</li><li>expect breaking changes</li></ul> | eclipse-temurin:8-jdk  |
-| x.x.x          | <ul><li>defined JanusGraph version</li><li>breaking changes are only in this repo</li></ul> | eclipse-temurin:8-jdk  |
-| x.x.x-revision | <ul><li>defined JanusGraph version</li><li>defined commit in JanusGraph-docker repo</li></ul> | eclipse-temurin:8-jdk  |
+| latest         | <ul><li>latest JanusGraph release</li><li>no breaking changes guarantees</li></ul> | eclipse-temurin:11-jre |
+| x.x            | <ul><li>newest patch-level version of JanusGraph</li><li>expect breaking changes</li></ul> | eclipse-temurin:8-jre  |
+| x.x.x          | <ul><li>defined JanusGraph version</li><li>breaking changes are only in this repo</li></ul> | eclipse-temurin:8-jre  |
+| x.x.x-revision | <ul><li>defined JanusGraph version</li><li>defined commit in JanusGraph-docker repo</li></ul> | eclipse-temurin:8-jre  |
 
 We collect a list of changes in our docker images build process in our [CHANGELOG.md](./CHANGELOG.md)
 

--- a/build/Dockerfile-openjdk11.template
+++ b/build/Dockerfile-openjdk11.template
@@ -42,7 +42,7 @@ RUN apt update -y && apt install -y gpg unzip curl && \
 COPY conf/ ${JANUS_HOME}/conf/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:11-jre-slim-buster
+FROM eclipse-temurin:11-jre
 
 ARG CREATED=test
 ARG REVISION=test

--- a/build/Dockerfile-openjdk8.template
+++ b/build/Dockerfile-openjdk8.template
@@ -42,7 +42,7 @@ RUN apt update -y && apt install -y gpg unzip curl && \
 COPY conf/ ${JANUS_HOME}/conf/
 COPY scripts/remote-connect.groovy ${JANUS_HOME}/scripts/
 
-FROM openjdk:8-jre-slim-buster
+FROM eclipse-temurin:8-jre
 
 ARG CREATED=test
 ARG REVISION=test


### PR DESCRIPTION
Also move back to an JRE base image after we have changed the base image to an JDK one by accident in this commit:
https://github.com/JanusGraph/janusgraph-docker/commit/29c443d303d0c45ce7c344992414332510341095

NOTE: Only merge after 0.6.3 was officially released.